### PR TITLE
fix build with SailfishOS

### DIFF
--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -343,6 +343,7 @@ QString NotificationMonitorPrivate::getAppName(const QString &id) const
 
 QString NotificationMonitorPrivate::guessAppId(const QString &id) const
 {
+#ifdef UUITK_EDITION
     QDir directory(DESKTOP_FILE_DIRECTORY);
 
     QString pattern = QRegularExpression::wildcardToRegularExpression(QString("%1_*.desktop").arg(id));
@@ -354,6 +355,7 @@ QString NotificationMonitorPrivate::guessAppId(const QString &id) const
             return extractedId;
         }
     }
+#endif
     return id;
 }
 

--- a/voicecallcontroller_sailfish.cpp
+++ b/voicecallcontroller_sailfish.cpp
@@ -27,8 +27,6 @@
 namespace watchfish
 {
 
-Q_LOGGING_CATEGORY(voiceCallControllerCat, "watchfish-VoiceCallController")
-
 VoiceCallControllerPrivate::VoiceCallControllerPrivate(VoiceCallController *q)
     : vcm(new OrgNemomobileVoicecallVoiceCallManagerInterface("org.nemomobile.voicecall",
                                                               "/", QDBusConnection::sessionBus(), this)),


### PR DESCRIPTION
Both issues were added because I didn't checked build with SailfishOS. I am sorry.

- The issue with Q_LOGGING_CATEGORY was introduced with VoicecallControllerBase class, when I was trying to make cleaner interface as you have suggested.

The issue with guessAppId:
The SailfishOS is still using old QRegExp. I was using QRegularExpression, and it seems whole class or some methods are missing, The method it self is not needed for SailfishOS so I have decided to remove method implementation. I decided to keep its definition in header file as difference is just on one place.