### PR TITLE
[music control] avoid segfault when bus is not avaialble

### DIFF
--- a/musiccontroller.cpp
+++ b/musiccontroller.cpp
@@ -319,6 +319,11 @@ int MusicController::volume() const
                                                    "org.freedesktop.DBus.Properties", "Get");
     call << "com.Meego.MainVolume2" << "CurrentStep";
 
+    if (d_ptr->_pulseBus == nullptr) {
+        qWarning() << "bus not available";
+        return volume;
+    }
+
     QDBusReply<QDBusVariant> volumeReply = d_ptr->_pulseBus->call(call);
     if (volumeReply.isValid()) {
         // Decide the new value for volume, taking limits into account
@@ -365,6 +370,10 @@ void MusicController::setVolume(const uint newVolume)
                                           "org.freedesktop.DBus.Properties", "Set");
     call << "com.Meego.MainVolume2" << "CurrentStep" << QVariant::fromValue(QDBusVariant(newVolume));
 
+    if (d_ptr->_pulseBus == nullptr) {
+        qWarning() << "bus not available";
+        return;
+    }
     QDBusError err = d_ptr->_pulseBus->call(call);
     if (err.isValid()) {
         qWarning() << err.message();

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -52,23 +52,31 @@ public:
 		RepeatPlaylist
 	};
 
+    Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
+    Q_PROPERTY(QString album READ album NOTIFY albumChanged FINAL)
+    Q_PROPERTY(QString artist READ artist NOTIFY artistChanged FINAL)
+    Q_PROPERTY(QString albumArt READ albumArt NOTIFY albumArtChanged FINAL)
+    Q_PROPERTY(int duration READ duration NOTIFY durationChanged FINAL)
+    Q_PROPERTY(bool shuffle READ shuffle NOTIFY shuffleChanged FINAL)
+    Q_PROPERTY(int volume READ volume WRITE setVolume NOTIFY volumeChanged FINAL)
+
+
     Q_INVOKABLE Status status() const;
     Q_INVOKABLE QString service() const;
 
     Q_INVOKABLE QVariantMap metadata() const;
 
-    Q_INVOKABLE QString title() const;
-    Q_INVOKABLE QString album() const;
-    Q_INVOKABLE QString artist() const;
+    QString title() const;
+    QString album() const;
+    QString artist() const;
+    QString albumArt() const;
 
-    Q_INVOKABLE QString albumArt() const;
-
-    Q_INVOKABLE int duration() const;
+    int duration() const;
 
     Q_INVOKABLE RepeatStatus repeat() const;
-    Q_INVOKABLE bool shuffle() const;
+    bool shuffle() const;
 
-    Q_INVOKABLE int volume() const;
+    int volume() const;
 
 public slots:
 	void play();

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -19,6 +19,7 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_H
 #define WATCHFISH_MUSICCONTROLLER_H
 
+#include <QObject>
 #include <QtCore/QLoggingCategory>
 
 namespace watchfish
@@ -51,23 +52,23 @@ public:
 		RepeatPlaylist
 	};
 
-	Status status() const;
-	QString service() const;
+    Q_INVOKABLE Status status() const;
+    Q_INVOKABLE QString service() const;
 
-	QVariantMap metadata() const;
+    Q_INVOKABLE QVariantMap metadata() const;
 
-	QString title() const;
-	QString album() const;
-	QString artist() const;
+    Q_INVOKABLE QString title() const;
+    Q_INVOKABLE QString album() const;
+    Q_INVOKABLE QString artist() const;
 
-	QString albumArt() const;
+    Q_INVOKABLE QString albumArt() const;
 
-	int duration() const;
+    Q_INVOKABLE int duration() const;
 
-	RepeatStatus repeat() const;
-	bool shuffle() const;
+    Q_INVOKABLE RepeatStatus repeat() const;
+    Q_INVOKABLE bool shuffle() const;
 
-	int volume() const;
+    Q_INVOKABLE int volume() const;
 
 public slots:
 	void play();


### PR DESCRIPTION
I have spotted some segfaults related to music control. Today I have tracked down, that segfaults comes when is the dbus interface not available. I have created testing app to find out details:
https://github.com/jmlich/mprisex

As is mentioned at https://github.com/sailfishos/qtmpris/pull/2 the qtmpris should be replaced in future with https://github.com/sailfishos/amber-mpris I am wondering if it this should be still part of libwatchfish. From my point of view, this can be probably used on all platforms easily.


