### PR TITLE
Suppress ayatana-indicator-sound notifications

### DIFF
--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -136,6 +136,11 @@ void NotificationMonitorPrivate::processIncomingNotification(quint32 id, const P
 		}
 	}
 
+	if (proto.appName == "ayatana-indicator-sound") {
+		qCDebug(notificationMonitorCat) << "Drop notification" << proto;
+		return;
+	}
+
 	if (is_new_notification) {
 		_notifs.insert(id, n);
 		emit q->notification(n);


### PR DESCRIPTION
The ayatana-indicator-sound displays volume change notifications on Ubuntu Touch. These notifications are unexpected and unnecessary on a smartwatch, so they are now suppressed.