### PR TITLE
Fix compilation of volumecontroller

### DIFF
--- a/volumecontroller.h
+++ b/volumecontroller.h
@@ -20,6 +20,7 @@
 #define WATCHFISH_VOLUMECONTROLLER_H
 
 #include <QtCore/QLoggingCategory>
+#include <QObject>
 
 namespace watchfish
 {


### PR DESCRIPTION
It seems QObject needs to be included explicitly when compiling with Qt 6. In my opinion, this change is harmless and compatible with Qt 5–based builds.

```
cmake .. -DFLAVOR=kirigami -DWATCHFISH_FEATURES=volume
```

```
/home/jmlich/workspace/ubports/libwatchfish/volumecontroller.h:31:33: error: invalid use of incomplete type ‘class QObject’
   31 | class VolumeController : public QObject
      |                                 ^~~~~~~
In file included from /usr/include/qt6/QtCore/qtdeprecationmarkers.h:8,
                 from /usr/include/qt6/QtCore/qtcoreexports.h:9,
                 from /usr/include/qt6/QtCore/qtcoreglobal.h:14,
                 from /usr/include/qt6/QtCore/qglobal.h:24,
                 from /usr/include/qt6/QtCore/qloggingcategory.h:8,
                 from /usr/include/qt6/QtCore/QLoggingCategory:1,
                 from /home/jmlich/workspace/ubports/libwatchfish/volumecontroller.h:22:
/usr/include/qt6/QtCore/qtclasshelpermacros.h:139:7: note: forward declaration of ‘class QObject’
  139 | class QObject;
      |       ^~~~~~~
/home/jmlich/workspace/ubports/libwatchfish/volumecontroller.cpp: In constructor ‘watchfish::VolumeController::VolumeController(QObject*)’:
/home/jmlich/workspace/ubports/libwatchfish/volumecontroller.cpp:88:7: error: type ‘QObject’ is not a direct base of ‘watchfish::VolumeController’
   88 |     : QObject(parent), d_ptr(new VolumeControllerPrivate(this))
      |       ^~~~~~~
gmake[2]: *** [CMakeFiles/libwatchfish.dir/build.make:91: CMakeFiles/libwatchfish.dir/volumecontroller.cpp.o] Error 1
```
