### PR TITLE
[qt6] Fix compilation of notification monitor

### DIFF
--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -278,7 +278,11 @@ ProtoNotification NotificationMonitorPrivate::parseNotifyCall(DBusMessage *msg) 
     // Lookup category info and merge it with the notification info if found.
 	if (hints.contains("category")) {
 		proto.hints = getCategoryInfo(hints["category"]);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		proto.hints.insert(hints);
+#else
 		proto.hints.unite(hints);
+#endif
 	} else {
 		proto.hints = hints;
 	}


### PR DESCRIPTION
```
/home/jmlich/workspace/ubports/libwatchfish/notificationmonitor.cpp: In member function ‘watchfish::ProtoNotification watchfish::NotificationMonitorPrivate::parseNotifyCall(DBusMessage*) const’:
/home/jmlich/workspace/ubports/libwatchfish/notificationmonitor.cpp:281:29: error: ‘class QHash<QString, QString>’ has no member named ‘unite’
  281 |                 proto.hints.unite(hints);
      |                             ^~~~~
gmake[2]: *** [CMakeFiles/libwatchfish.dir/build.make:79: CMakeFiles/libwatchfish.dir/notificationmonitor.cpp.o] Error 1
```