### PR TITLE
feat: port from QtMpris to AmberMpris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 
 # Feature: music
 if(WATCHFISH_FEATURES MATCHES "music")
-    pkg_check_modules(MPRIS REQUIRED mpris-qt5)
+    pkg_check_modules(MPRIS REQUIRED ambermpris)
     target_include_directories(libwatchfish PUBLIC ${MPRIS_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${MPRIS_LIBRARIES})
 

--- a/musiccontroller_p.h
+++ b/musiccontroller_p.h
@@ -19,8 +19,8 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_P_H
 #define WATCHFISH_MUSICCONTROLLER_P_H
 
-#include <MprisQt/mpris.h>
-#include <MprisQt/mprismanager.h>
+#include <AmberMpris/mpris.h>
+#include <AmberMpris/mprismanager.h>
 
 #include "musiccontroller.h"
 


### PR DESCRIPTION
QtMpris has been renamed upstream to AmberMpris and the latter has had new releases since then.