### PR TITLE
[Qt6] Allow to compile libwatchfish using qt6 for music controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,34 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(libwatchfish STATIC)
 
+# Make sure to choose same Qt version as rest of project
+if(TARGET Qt6::Core)
+    set(QT_VERSION_MAJOR 6)
+    find_package(Qt6 REQUIRED COMPONENTS Core DBus)
+elseif(TARGET Qt5::Core)
+    set(QT_VERSION_MAJOR 5)
+    find_package(Qt5 REQUIRED COMPONENTS Core DBus)
+else()
+    # Use Qt6 first if available
+    find_package(Qt6 COMPONENTS Core DBus QUIET)
+    if(Qt6_FOUND)
+        set(QT_VERSION_MAJOR 6)
+    else()
+        find_package(Qt5 REQUIRED COMPONENTS Core Xml)
+        set(QT_VERSION_MAJOR 5)
+    endif()
+endif()
+
+message(STATUS "libwatchfish: using Qt ${QT_VERSION_MAJOR}")
+
 find_package(PkgConfig REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Core DBus)
 
 target_include_directories(libwatchfish PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(libwatchfish PUBLIC Qt5::Core Qt5::DBus)
+target_link_libraries(libwatchfish PUBLIC
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+)
+
 
 set(SOURCES)
 set(HEADERS)
@@ -52,7 +75,7 @@ endif()
 # Feature: walltime
 if(WATCHFISH_FEATURES MATCHES "walltime")
 
-    pkg_check_modules(TIMED REQUIRED timed-qt5)
+    pkg_check_modules(TIMED REQUIRED timed-qt${QT_VERSION_MAJOR})
     target_include_directories(libwatchfish PUBLIC ${TIMED_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${TIMED_LIBRARIES})
 
@@ -67,7 +90,11 @@ endif()
 
 # Feature: music
 if(WATCHFISH_FEATURES MATCHES "music")
-    pkg_check_modules(MPRIS REQUIRED ambermpris)
+    if(QT_VERSION_MAJOR EQUAL 6)
+        pkg_check_modules(MPRIS REQUIRED ambermpris6)
+    else()
+        pkg_check_modules(MPRIS REQUIRED ambermpris)
+    endif()
     target_include_directories(libwatchfish PUBLIC ${MPRIS_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${MPRIS_LIBRARIES})
 
@@ -78,13 +105,13 @@ if(WATCHFISH_FEATURES MATCHES "music")
         musiccontroller.h
         musiccontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 # Feature: calendar
 if(WATCHFISH_FEATURES MATCHES "calendar")
     if(FLAVOR STREQUAL "silica")
-        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt5)
+        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt${QT_VERSION_MAJOR})
         target_include_directories(libwatchfish PUBLIC ${LIBMKCAL_INCLUDE_DIRS})
         target_link_libraries(libwatchfish PUBLIC ${LIBMKCAL_LIBRARIES})
 
@@ -101,9 +128,10 @@ if(WATCHFISH_FEATURES MATCHES "calendar")
             calendarevent.h
         )
     elseif(FLAVOR STREQUAL "uuitk")
-        find_package(Qt5 COMPONENTS Organizer)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Organizer)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Organizer)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Organizer)
+
 
         list(APPEND HEADERS
             calendarsource.h
@@ -126,9 +154,9 @@ endif()
 # Feature: voicecall
 if(WATCHFISH_FEATURES MATCHES "voicecall")
     if(FLAVOR STREQUAL "silica")
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC MER_EDITION_SAILFISH)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_sailfish.cpp
@@ -140,12 +168,12 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             voicecallcontroller_p.h
             voicecallcontrollerbase.h
         )
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
     elseif(FLAVOR STREQUAL "uuitk") # ubuntu touch
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_ubuntu.cpp
@@ -158,8 +186,8 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             callchannelobserver.h
             voicecallcontrollerbase.h
         )
-        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt5/)
-        target_link_libraries(libwatchfish PUBLIC telepathy-qt5)
+        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt${QT_VERSION_MAJOR}/)
+        target_link_libraries(libwatchfish PUBLIC telepathy-qt${QT_VERSION_MAJOR})
     endif()
 endif()
 
@@ -172,7 +200,7 @@ if(WATCHFISH_FEATURES MATCHES "volume")
         volumecontroller.h
         volumecontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 target_sources(libwatchfish PUBLIC ${HEADERS} PRIVATE ${SOURCES} ${DBUS_INTERFACES_GEN})

--- a/musiccontroller.cpp
+++ b/musiccontroller.cpp
@@ -21,6 +21,7 @@
 #include <QDBusMessage>
 #include <QDBusReply>
 
+#include "mprismetadata.h"
 #include "musiccontroller.h"
 #include "musiccontroller_p.h"
 
@@ -30,18 +31,19 @@ namespace watchfish
 Q_LOGGING_CATEGORY(musicControllerCat, "watchfish-MusicController")
 
 MusicControllerPrivate::MusicControllerPrivate(MusicController *q)
-	: manager(new MprisManager(this)), q_ptr(q)
+	: controller(new Amber::MprisController(this)), q_ptr(q)
 {
-	connect(manager, &MprisManager::currentServiceChanged,
+	connect(controller, &Amber::MprisController::currentServiceChanged,
 			this, &MusicControllerPrivate::handleCurrentServiceChanged);
-	connect(manager, &MprisManager::playbackStatusChanged,
+	connect(controller, &Amber::MprisController::playbackStatusChanged,
 			this, &MusicControllerPrivate::handlePlaybackStatusChanged);
-	connect(manager, &MprisManager::metadataChanged,
-			this, &MusicControllerPrivate::handleMetadataChanged);
-	connect(manager, &MprisManager::shuffleChanged,
+	connect(controller, &Amber::MprisController::shuffleChanged,
 			q, &MusicController::shuffleChanged);
-	connect(manager, &MprisManager::loopStatusChanged,
+	connect(controller, &Amber::MprisController::loopStatusChanged,
 			q, &MusicController::repeatChanged);
+
+	connect(controller->metaData(), &Amber::MprisMetaData::metaDataChanged,
+			this, &MusicControllerPrivate::handleMetadataChanged);
 }
 
 MusicControllerPrivate::~MusicControllerPrivate()
@@ -104,17 +106,17 @@ QString MusicControllerPrivate::findAlbumArt(const QString &artist, const QStrin
 void MusicControllerPrivate::updateStatus()
 {
 	Q_Q(MusicController);
-	QString service = manager->currentService();
+	QString service = controller->currentService();
 	MusicController::Status newStatus;
 
 	if (service.isEmpty()) {
 		newStatus =  MusicController::StatusNoPlayer;
 	} else {
-		switch (manager->playbackStatus()) {
-		case Mpris::Playing:
+		switch (controller->playbackStatus()) {
+		case Amber::Mpris::Playing:
 			newStatus = MusicController::StatusPlaying;
 			break;
-		case Mpris::Paused:
+		case Amber::Mpris::Paused:
 			newStatus = MusicController::StatusPaused;
 			break;
 		default:
@@ -142,14 +144,12 @@ void MusicControllerPrivate::updateAlbumArt()
 void MusicControllerPrivate::updateMetadata()
 {
 	Q_Q(MusicController);
-	QVariantMap metadata = manager->metadata();
+	Amber::MprisMetaData *metadata = controller->metaData();
 	bool checkAlbumArt = false;
 
-	qCDebug(musicControllerCat()) << metadata;
-
-	QString newArtist = metadata.value("xesam:artist").toString(),
-			newAlbum = metadata.value("xesam:album").toString(),
-			newTitle = metadata.value("xesam:title").toString();
+	QString newArtist = metadata->contributingArtist().toString(),
+			newAlbum = metadata->albumTitle().toString(),
+			newTitle = metadata->title().toString();
 
 	if (newArtist != curArtist) {
 		curArtist = newArtist;
@@ -172,7 +172,7 @@ void MusicControllerPrivate::updateMetadata()
 		updateAlbumArt();
 	}
 
-	int newDuration = metadata.value("mpris:length").toULongLong() / 1000UL;
+	int newDuration = metadata->duration().toULongLong();
 	if (newDuration != curDuration) {
 		curDuration = newDuration;
 		emit q->durationChanged();
@@ -184,14 +184,14 @@ void MusicControllerPrivate::updateMetadata()
 void MusicControllerPrivate::handleCurrentServiceChanged()
 {
 	Q_Q(MusicController);
-	qCDebug(musicControllerCat()) << manager->currentService();
+	qCDebug(musicControllerCat()) << controller->currentService();
 	updateStatus();
 	emit q->serviceChanged();
 }
 
 void MusicControllerPrivate::handlePlaybackStatusChanged()
 {
-	qCDebug(musicControllerCat()) << manager->playbackStatus();
+	qCDebug(musicControllerCat()) << controller->playbackStatus();
 	updateStatus();
 }
 
@@ -249,16 +249,16 @@ MusicController::Status MusicController::status() const
 	return d->curStatus;
 }
 
+Amber::MprisMetaData MusicController::metadata() const
+{
+	Q_D(const MusicController);
+	return d->controller->metaData();
+}
+
 QString MusicController::service() const
 {
 	Q_D(const MusicController);
-	return d->manager->currentService();
-}
-
-QVariantMap MusicController::metadata() const
-{
-	Q_D(const MusicController);
-	return d->manager->metadata();
+	return d->controller->currentService();
 }
 
 QString MusicController::title() const
@@ -294,13 +294,13 @@ int MusicController::duration() const
 MusicController::RepeatStatus MusicController::repeat() const
 {
 	Q_D(const MusicController);
-	switch (d->manager->loopStatus()) {
-	case Mpris::None:
+	switch (d->controller->loopStatus()) {
+	case Amber::Mpris::LoopStatus::LoopNone:
 	default:
 		return RepeatNone;
-	case Mpris::Track:
+	case Amber::Mpris::LoopStatus::LoopTrack:
 		return RepeatTrack;
-	case Mpris::Playlist:
+	case Amber::Mpris::LoopStatus::LoopPlaylist:
 		return RepeatPlaylist;
 	}
 }
@@ -308,7 +308,7 @@ MusicController::RepeatStatus MusicController::repeat() const
 bool MusicController::shuffle() const
 {
 	Q_D(const MusicController);
-	return d->manager->shuffle();
+	return d->controller->shuffle();
 }
 
 int MusicController::volume() const
@@ -335,31 +335,31 @@ int MusicController::volume() const
 void MusicController::play()
 {
 	Q_D(MusicController);
-	d->manager->play();
+	d->controller->play();
 }
 
 void MusicController::pause()
 {
 	Q_D(MusicController);
-	d->manager->pause();
+	d->controller->pause();
 }
 
 void MusicController::playPause()
 {
 	Q_D(MusicController);
-	d->manager->playPause();
+	d->controller->playPause();
 }
 
 void MusicController::next()
 {
 	Q_D(MusicController);
-	d->manager->next();
+	d->controller->next();
 }
 
 void MusicController::previous()
 {
 	Q_D(MusicController);
-	d->manager->previous();
+	d->controller->previous();
 }
 
 void MusicController::setVolume(const uint newVolume)

--- a/musiccontroller.cpp
+++ b/musiccontroller.cpp
@@ -21,6 +21,12 @@
 #include <QDBusMessage>
 #include <QDBusReply>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
 #include "mprismetadata.h"
 #include "musiccontroller.h"
 #include "musiccontroller_p.h"
@@ -57,13 +63,21 @@ MusicControllerPrivate::~MusicControllerPrivate()
 
 QString MusicControllerPrivate::stripAlbumArtComponent(const QString& component)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	static QRegularExpression rsb("\\[.*\\]");
+	static QRegularExpression rfb("\\{.*\\}");
+	static QRegularExpression rrb("\\(.*\\)");
+	static QRegularExpression stripB("^[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
+	static QRegularExpression stripE("[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
+#else
 	static QRegExp rsb("\\[.*\\]");
 	static QRegExp rfb("{.*}");
 	static QRegExp rrb("\\(.*\\)");
 	static QRegExp stripB("^[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
 	static QRegExp stripE("[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
-	QString s(component);
+#endif
 
+	QString s(component);
 	if (s.isEmpty()) {
 		return QString(" ");
 	}

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -19,6 +19,7 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_H
 #define WATCHFISH_MUSICCONTROLLER_H
 
+#include <AmberMpris/mprismetadata.h>
 #include <QtCore/QLoggingCategory>
 
 namespace watchfish
@@ -54,7 +55,7 @@ public:
 	Status status() const;
 	QString service() const;
 
-	QVariantMap metadata() const;
+	Amber::MprisMetaData metadata() const;
 
 	QString title() const;
 	QString album() const;

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -19,6 +19,7 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_H
 #define WATCHFISH_MUSICCONTROLLER_H
 
+#include <QObject>
 #include <AmberMpris/mprismetadata.h>
 #include <QtCore/QLoggingCategory>
 
@@ -51,9 +52,18 @@ public:
 		RepeatTrack,
 		RepeatPlaylist
 	};
+	Q_ENUM(RepeatStatus)
 
-	Status status() const;
-	QString service() const;
+	Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
+	Q_PROPERTY(QString album READ album NOTIFY albumChanged FINAL)
+	Q_PROPERTY(QString artist READ artist NOTIFY artistChanged FINAL)
+	Q_PROPERTY(QString albumArt READ albumArt NOTIFY albumArtChanged FINAL)
+	Q_PROPERTY(int duration READ duration NOTIFY durationChanged FINAL)
+	Q_PROPERTY(bool shuffle READ shuffle NOTIFY shuffleChanged FINAL)
+	Q_PROPERTY(int volume READ volume WRITE setVolume NOTIFY volumeChanged FINAL)
+
+	Q_INVOKABLE Status status() const;
+	Q_INVOKABLE QString service() const;
 
 	Amber::MprisMetaData metadata() const;
 
@@ -65,7 +75,7 @@ public:
 
 	int duration() const;
 
-	RepeatStatus repeat() const;
+	Q_INVOKABLE RepeatStatus repeat() const;
 	bool shuffle() const;
 
 	int volume() const;

--- a/musiccontroller_p.h
+++ b/musiccontroller_p.h
@@ -20,7 +20,7 @@
 #define WATCHFISH_MUSICCONTROLLER_P_H
 
 #include <AmberMpris/mpris.h>
-#include <AmberMpris/mprismanager.h>
+#include <AmberMpris/mpriscontroller.h>
 
 #include "musiccontroller.h"
 
@@ -36,7 +36,7 @@ public:
 	~MusicControllerPrivate();
 
 public:
-	MprisManager *manager;
+	Amber::MprisController *controller;
 	MusicController::Status curStatus;
 	QString curTitle;
 	QString curAlbum;


### PR DESCRIPTION
I have tiny sample application to test music controller only
https://github.com/jmlich/mprisex

- [x] compilation of mprisex + libwatchfish with Qt5
- [x] compilation of mprisex + libwatchfish with Qt6
- [x] compilation with amazfish with flavor kirigami (still qt5)

it is built on top of https://github.com/piggz/libwatchfish/pull/18