### PR TITLE
Qt6 and use of becameMonitor for notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 3.16)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+
 add_library(libwatchfish STATIC)
 
 # Make sure to choose same Qt version as rest of project
@@ -26,6 +27,12 @@ else()
         find_package(Qt5 REQUIRED COMPONENTS Core Xml)
         set(QT_VERSION_MAJOR 5)
     endif()
+endif()
+
+if(QT_VERSION_MAJOR EQUAL 5)
+    macro(qt_add_dbus_interface outfiles interface basename)
+        qt5_add_dbus_interface(${outfiles} ${interface} ${basename})
+    endmacro()
 endif()
 
 message(STATUS "libwatchfish: using Qt ${QT_VERSION_MAJOR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,34 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(libwatchfish STATIC)
 
+# Make sure to choose same Qt version as rest of project
+if(TARGET Qt6::Core)
+    set(QT_VERSION_MAJOR 6)
+    find_package(Qt6 REQUIRED COMPONENTS Core DBus)
+elseif(TARGET Qt5::Core)
+    set(QT_VERSION_MAJOR 5)
+    find_package(Qt5 REQUIRED COMPONENTS Core DBus)
+else()
+    # Use Qt6 first if available
+    find_package(Qt6 COMPONENTS Core DBus QUIET)
+    if(Qt6_FOUND)
+        set(QT_VERSION_MAJOR 6)
+    else()
+        find_package(Qt5 REQUIRED COMPONENTS Core Xml)
+        set(QT_VERSION_MAJOR 5)
+    endif()
+endif()
+
+message(STATUS "libwatchfish: using Qt ${QT_VERSION_MAJOR}")
+
 find_package(PkgConfig REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Core DBus)
 
 target_include_directories(libwatchfish PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(libwatchfish PUBLIC Qt5::Core Qt5::DBus)
+target_link_libraries(libwatchfish PUBLIC
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+)
+
 
 set(SOURCES)
 set(HEADERS)
@@ -52,7 +75,7 @@ endif()
 # Feature: walltime
 if(WATCHFISH_FEATURES MATCHES "walltime")
 
-    pkg_check_modules(TIMED REQUIRED timed-qt5)
+    pkg_check_modules(TIMED REQUIRED timed-qt${QT_VERSION_MAJOR})
     target_include_directories(libwatchfish PUBLIC ${TIMED_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${TIMED_LIBRARIES})
 
@@ -67,7 +90,11 @@ endif()
 
 # Feature: music
 if(WATCHFISH_FEATURES MATCHES "music")
-    pkg_check_modules(MPRIS REQUIRED ambermpris)
+    if(QT_VERSION_MAJOR EQUAL 6)
+        pkg_check_modules(MPRIS REQUIRED ambermpris6)
+    else()
+        pkg_check_modules(MPRIS REQUIRED ambermpris)
+    endif()
     target_include_directories(libwatchfish PUBLIC ${MPRIS_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${MPRIS_LIBRARIES})
 
@@ -78,13 +105,13 @@ if(WATCHFISH_FEATURES MATCHES "music")
         musiccontroller.h
         musiccontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 # Feature: calendar
 if(WATCHFISH_FEATURES MATCHES "calendar")
     if(FLAVOR STREQUAL "silica")
-        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt5)
+        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt${QT_VERSION_MAJOR})
         target_include_directories(libwatchfish PUBLIC ${LIBMKCAL_INCLUDE_DIRS})
         target_link_libraries(libwatchfish PUBLIC ${LIBMKCAL_LIBRARIES})
 
@@ -101,9 +128,10 @@ if(WATCHFISH_FEATURES MATCHES "calendar")
             calendarevent.h
         )
     elseif(FLAVOR STREQUAL "uuitk")
-        find_package(Qt5 COMPONENTS Organizer)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Organizer)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Organizer)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Organizer)
+
 
         list(APPEND HEADERS
             calendarsource.h
@@ -126,9 +154,9 @@ endif()
 # Feature: voicecall
 if(WATCHFISH_FEATURES MATCHES "voicecall")
     if(FLAVOR STREQUAL "silica")
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC MER_EDITION_SAILFISH)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_sailfish.cpp
@@ -140,12 +168,12 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             voicecallcontroller_p.h
             voicecallcontrollerbase.h
         )
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
     elseif(FLAVOR STREQUAL "uuitk") # ubuntu touch
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_ubuntu.cpp
@@ -158,8 +186,8 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             callchannelobserver.h
             voicecallcontrollerbase.h
         )
-        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt5/)
-        target_link_libraries(libwatchfish PUBLIC telepathy-qt5)
+        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt${QT_VERSION_MAJOR}/)
+        target_link_libraries(libwatchfish PUBLIC telepathy-qt${QT_VERSION_MAJOR})
     endif()
 endif()
 
@@ -172,7 +200,7 @@ if(WATCHFISH_FEATURES MATCHES "volume")
         volumecontroller.h
         volumecontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 target_sources(libwatchfish PUBLIC ${HEADERS} PRIVATE ${SOURCES} ${DBUS_INTERFACES_GEN})

--- a/musiccontroller.cpp
+++ b/musiccontroller.cpp
@@ -21,6 +21,12 @@
 #include <QDBusMessage>
 #include <QDBusReply>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
 #include "mprismetadata.h"
 #include "musiccontroller.h"
 #include "musiccontroller_p.h"
@@ -57,13 +63,21 @@ MusicControllerPrivate::~MusicControllerPrivate()
 
 QString MusicControllerPrivate::stripAlbumArtComponent(const QString& component)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	static QRegularExpression rsb("\\[.*\\]");
+	static QRegularExpression rfb("\\{.*\\}");
+	static QRegularExpression rrb("\\(.*\\)");
+	static QRegularExpression stripB("^[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
+	static QRegularExpression stripE("[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
+#else
 	static QRegExp rsb("\\[.*\\]");
 	static QRegExp rfb("{.*}");
 	static QRegExp rrb("\\(.*\\)");
 	static QRegExp stripB("^[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
 	static QRegExp stripE("[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
-	QString s(component);
+#endif
 
+	QString s(component);
 	if (s.isEmpty()) {
 		return QString(" ");
 	}

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -19,6 +19,7 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_H
 #define WATCHFISH_MUSICCONTROLLER_H
 
+#include <QObject>
 #include <AmberMpris/mprismetadata.h>
 #include <QtCore/QLoggingCategory>
 
@@ -51,9 +52,18 @@ public:
 		RepeatTrack,
 		RepeatPlaylist
 	};
+	Q_ENUM(RepeatStatus)
 
-	Status status() const;
-	QString service() const;
+	Q_PROPERTY(QString title READ title NOTIFY titleChanged FINAL)
+	Q_PROPERTY(QString album READ album NOTIFY albumChanged FINAL)
+	Q_PROPERTY(QString artist READ artist NOTIFY artistChanged FINAL)
+	Q_PROPERTY(QString albumArt READ albumArt NOTIFY albumArtChanged FINAL)
+	Q_PROPERTY(int duration READ duration NOTIFY durationChanged FINAL)
+	Q_PROPERTY(bool shuffle READ shuffle NOTIFY shuffleChanged FINAL)
+	Q_PROPERTY(int volume READ volume WRITE setVolume NOTIFY volumeChanged FINAL)
+
+	Q_INVOKABLE Status status() const;
+	Q_INVOKABLE QString service() const;
 
 	Amber::MprisMetaData metadata() const;
 
@@ -65,7 +75,7 @@ public:
 
 	int duration() const;
 
-	RepeatStatus repeat() const;
+	Q_INVOKABLE RepeatStatus repeat() const;
 	bool shuffle() const;
 
 	int volume() const;

--- a/notification.cpp
+++ b/notification.cpp
@@ -63,6 +63,7 @@ Notification::Notification(uint id, QObject *parent) : QObject(parent), d_ptr(ne
 
 Notification::~Notification()
 {
+	delete d_ptr;
 }
 
 uint Notification::id() const

--- a/notification.h
+++ b/notification.h
@@ -57,7 +57,7 @@ class Notification : public QObject
 
 
 public:
-	explicit Notification(uint id, QObject *parent = 0);
+	explicit Notification(uint id = 0, QObject *parent = 0);
 	~Notification();
 
 	enum CloseReason {

--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -278,7 +278,11 @@ ProtoNotification NotificationMonitorPrivate::parseNotifyCall(DBusMessage *msg) 
     // Lookup category info and merge it with the notification info if found.
 	if (hints.contains("category")) {
 		proto.hints = getCategoryInfo(hints["category"]);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		proto.hints.insert(hints);
+#else
 		proto.hints.unite(hints);
+#endif
 	} else {
 		proto.hints = hints;
 	}

--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -16,12 +16,12 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QRegularExpression>
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
 #include <QtCore/QMessageLogger>
 #include <QtCore/QSettings>
 #include <QtCore/QSocketNotifier>
-#include <QRegularExpression>
 
 #include "notification.h"
 #include "notificationmonitor.h"
@@ -45,8 +45,11 @@ QDebug operator<<(QDebug &debug, const ProtoNotification &proto)
 }
 
 NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
-	: q_ptr(q)
+    : QObject(q), q_ptr(q)
 {
+	connect(this, &NotificationMonitorPrivate::notificationClosed, q,
+		&NotificationMonitor::notificationClosed);
+
 	DBusError error = DBUS_ERROR_INIT;
 	_conn = dbus_bus_get_private(DBUS_BUS_SESSION, &error);
 	if (!_conn) {
@@ -108,11 +111,8 @@ NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
 
 NotificationMonitorPrivate::~NotificationMonitorPrivate()
 {
-	QMap<quint32, Notification*>::iterator it = _notifs.begin();
-	while (it != _notifs.end()) {
-		delete it.value();
-	}
-
+	qDeleteAll(_notifs);
+	_notifs.clear();
 #if 0 /* No need to remove match rules since we're closing the connection. */
 	removeMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
 	removeMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
@@ -184,6 +184,8 @@ void NotificationMonitorPrivate::processIncomingNotification(quint32 id, const P
 void NotificationMonitorPrivate::processCloseNotification(quint32 id, quint32 reason)
 {
 	qCDebug(notificationMonitorCat) << "Close notification" << id << reason;
+	emit notificationClosed(id, reason);
+
 	Notification *n = _notifs.value(id, 0);
 	if (n) {
 		_notifs.remove(id);
@@ -513,5 +515,11 @@ NotificationMonitor::~NotificationMonitor()
 {
 	delete d_ptr;
 }
+
+Notification *NotificationMonitor::getNotification(uint id) const {
+	Q_D(const NotificationMonitor);
+	return d->_notifs.value(id, nullptr);
+}
+
 
 }

--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -59,9 +59,43 @@ NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
 	dbus_connection_set_watch_functions(_conn, busWatchAdd, busWatchRemove,
 										busWatchToggle, this, NULL);
 
-	addMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
-	addMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
-	addMatchRule("type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'");
+	bool became_monitor = false;
+	const char *rules[] = {
+		"type='method_call',interface='org.freedesktop.Notifications',member='Notify'",
+		"type='method_return',sender='org.freedesktop.Notifications'",
+		"type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'"
+	};
+
+	DBusMessage *msg = dbus_message_new_method_call("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus.Monitoring", "BecomeMonitor");
+	if (msg) {
+		dbus_uint32_t flags = 0;
+		DBusMessageIter iter, sub;
+		dbus_message_iter_init_append(msg, &iter);
+		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "s", &sub);
+		for (int i = 0; i < 3; ++i) {
+			dbus_message_iter_append_basic(&sub, DBUS_TYPE_STRING, &rules[i]);
+		}
+		dbus_message_iter_close_container(&iter, &sub);
+		dbus_message_iter_append_basic(&iter, DBUS_TYPE_UINT32, &flags);
+
+		DBusMessage *reply = dbus_connection_send_with_reply_and_block(_conn, msg, -1, &error);
+		if (reply) {
+			dbus_message_unref(reply);
+			became_monitor = true;
+			qCDebug(notificationMonitorCat) << "Became monitor";
+		} else {
+			qCDebug(notificationMonitorCat) << "Could not become monitor:" << (error.message ? error.message : "unknown error");
+			dbus_error_free(&error);
+		}
+		dbus_message_unref(msg);
+	}
+
+	if (!became_monitor) {
+		qCDebug(notificationMonitorCat) << "Falling back to legacy eavesdropping";
+		addMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
+		addMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
+		addMatchRule("type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'");
+	}
 
 	dbus_bool_t result = dbus_connection_add_filter(_conn, busMessageFilter,
 													this, NULL);

--- a/notificationmonitor.h
+++ b/notificationmonitor.h
@@ -41,9 +41,12 @@ public:
 	explicit NotificationMonitor(QObject *parent = 0);
 	~NotificationMonitor();
 
+    Q_INVOKABLE watchfish::Notification* getNotification(uint id) const;
+
 signals:
     /** Emitted when a notification arrives. */
     void notification(watchfish::Notification *n);
+    void notificationClosed(quint32 nid, quint32 reason);
 
 private:
 	NotificationMonitorPrivate * const d_ptr;

--- a/notificationmonitor_p.h
+++ b/notificationmonitor_p.h
@@ -55,6 +55,9 @@ public:
     explicit NotificationMonitorPrivate(NotificationMonitor *q);
 	~NotificationMonitorPrivate();
 
+signals:
+    void notificationClosed(quint32 nid, quint32 reason);
+
 private:
 	/** Converts a ProtoNotification into a Notification object and raises it. */
 	void processIncomingNotification(quint32 id, const ProtoNotification &proto);


### PR DESCRIPTION
Fixes build with Qt6 of notification monitor, introduces cmake detection of used version of qt in main project. Additionally, changes use of deprecated eavesdropping to bacemeMonitor method, which fixes it new systems. The eavesdropping method is still there for backward compatibility.

I have created an example to demonstrate notification https://github.com/jmlich/notifex 
Next I have github.com/jmlich/mprisex and https://github.com/jmlich/calendarex to test other features separately. 

Proof by example https://www.youtube.com/watch?v=lnXAY7P6Z4w

- [x] compilation of mprisex/notifex/calendarex + libwatchfish with Qt5
- [x] compilation of mprisex/notifex + libwatchfish with Qt6
- [x] compilation of amazfish with flavor kirigami (still qt5)
- [x] compilation of amazfish on SailfishOS `zypper install amber-mpris-devel`