### PR TITLE
[Qt6] compatibility with Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,39 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(libwatchfish STATIC)
 
+# Make sure to choose same Qt version as rest of project
+if(TARGET Qt6::Core)
+    set(QT_VERSION_MAJOR 6)
+    find_package(Qt6 REQUIRED COMPONENTS Core DBus)
+elseif(TARGET Qt5::Core)
+    set(QT_VERSION_MAJOR 5)
+    find_package(Qt5 REQUIRED COMPONENTS Core DBus)
+else()
+    # Use Qt6 first if available
+    find_package(Qt6 COMPONENTS Core DBus QUIET)
+    if(Qt6_FOUND)
+        set(QT_VERSION_MAJOR 6)
+    else()
+        find_package(Qt5 REQUIRED COMPONENTS Core Xml)
+        set(QT_VERSION_MAJOR 5)
+    endif()
+endif()
+
+if(QT_VERSION_MAJOR EQUAL 5)
+    macro(qt_add_dbus_interface outfiles interface basename)
+        qt5_add_dbus_interface(${outfiles} ${interface} ${basename})
+    endmacro()
+endif()
+
+message(STATUS "libwatchfish: using Qt ${QT_VERSION_MAJOR}")
+
 find_package(PkgConfig REQUIRED)
-find_package(Qt5 REQUIRED COMPONENTS Core DBus)
 
 target_include_directories(libwatchfish PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(libwatchfish PUBLIC Qt5::Core Qt5::DBus)
+target_link_libraries(libwatchfish PUBLIC
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+)
 
 set(SOURCES)
 set(HEADERS)
@@ -52,7 +80,7 @@ endif()
 # Feature: walltime
 if(WATCHFISH_FEATURES MATCHES "walltime")
 
-    pkg_check_modules(TIMED REQUIRED timed-qt5)
+    pkg_check_modules(TIMED REQUIRED timed-qt${QT_VERSION_MAJOR})
     target_include_directories(libwatchfish PUBLIC ${TIMED_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${TIMED_LIBRARIES})
 
@@ -67,7 +95,11 @@ endif()
 
 # Feature: music
 if(WATCHFISH_FEATURES MATCHES "music")
-    pkg_check_modules(MPRIS REQUIRED ambermpris)
+    if(QT_VERSION_MAJOR EQUAL 6)
+        pkg_check_modules(MPRIS REQUIRED ambermpris6)
+    else()
+        pkg_check_modules(MPRIS REQUIRED ambermpris)
+    endif()
     target_include_directories(libwatchfish PUBLIC ${MPRIS_INCLUDE_DIRS})
     target_link_libraries(libwatchfish PUBLIC ${MPRIS_LIBRARIES})
 
@@ -78,13 +110,13 @@ if(WATCHFISH_FEATURES MATCHES "music")
         musiccontroller.h
         musiccontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 # Feature: calendar
 if(WATCHFISH_FEATURES MATCHES "calendar")
     if(FLAVOR STREQUAL "silica")
-        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt5)
+        pkg_check_modules(LIBMKCAL REQUIRED libmkcal-qt${QT_VERSION_MAJOR})
         target_include_directories(libwatchfish PUBLIC ${LIBMKCAL_INCLUDE_DIRS})
         target_link_libraries(libwatchfish PUBLIC ${LIBMKCAL_LIBRARIES})
 
@@ -101,9 +133,9 @@ if(WATCHFISH_FEATURES MATCHES "calendar")
             calendarevent.h
         )
     elseif(FLAVOR STREQUAL "uuitk")
-        find_package(Qt5 COMPONENTS Organizer)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Organizer)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Organizer)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Organizer)
 
         list(APPEND HEADERS
             calendarsource.h
@@ -126,9 +158,9 @@ endif()
 # Feature: voicecall
 if(WATCHFISH_FEATURES MATCHES "voicecall")
     if(FLAVOR STREQUAL "silica")
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC MER_EDITION_SAILFISH)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_sailfish.cpp
@@ -140,12 +172,12 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             voicecallcontroller_p.h
             voicecallcontrollerbase.h
         )
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
-        qt5_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCallManager.xml voicecallmanager_interface)
+        qt_add_dbus_interface(DBUS_INTERFACES_GEN org.nemomobile.voicecall.VoiceCall.xml voicecall_interface)
     elseif(FLAVOR STREQUAL "uuitk") # ubuntu touch
-        find_package(Qt5 COMPONENTS Contacts)
+        find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Contacts)
         target_compile_definitions(libwatchfish PUBLIC UUITK_EDITION)
-        target_link_libraries(libwatchfish PUBLIC Qt5::Contacts)
+        target_link_libraries(libwatchfish PUBLIC Qt${QT_VERSION_MAJOR}::Contacts)
 
         list(APPEND SOURCES
             voicecallcontroller_ubuntu.cpp
@@ -158,8 +190,8 @@ if(WATCHFISH_FEATURES MATCHES "voicecall")
             callchannelobserver.h
             voicecallcontrollerbase.h
         )
-        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt5/)
-        target_link_libraries(libwatchfish PUBLIC telepathy-qt5)
+        target_include_directories(libwatchfish PUBLIC /usr/include/telepathy-qt${QT_VERSION_MAJOR}/)
+        target_link_libraries(libwatchfish PUBLIC telepathy-qt${QT_VERSION_MAJOR})
     endif()
 endif()
 
@@ -172,7 +204,7 @@ if(WATCHFISH_FEATURES MATCHES "volume")
         volumecontroller.h
         volumecontroller_p.h
     )
-    qt5_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
+    qt_add_dbus_interface(DBUS_INTERFACES_GEN com.Meego.MainVolume2.xml mainvolume2_interface)
 endif()
 
 target_sources(libwatchfish PUBLIC ${HEADERS} PRIVATE ${SOURCES} ${DBUS_INTERFACES_GEN})

--- a/musiccontroller.cpp
+++ b/musiccontroller.cpp
@@ -21,6 +21,12 @@
 #include <QDBusMessage>
 #include <QDBusReply>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QRegularExpression>
+#else
+#include <QRegExp>
+#endif
+
 #include "mprismetadata.h"
 #include "musiccontroller.h"
 #include "musiccontroller_p.h"
@@ -57,11 +63,19 @@ MusicControllerPrivate::~MusicControllerPrivate()
 
 QString MusicControllerPrivate::stripAlbumArtComponent(const QString& component)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+	static QRegularExpression rsb("\\[.*\\]");
+	static QRegularExpression rfb("\\{.*\\}");
+	static QRegularExpression rrb("\\(.*\\)");
+	static QRegularExpression stripB("^[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
+	static QRegularExpression stripE("[()_{}\\[\\]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
+#else
 	static QRegExp rsb("\\[.*\\]");
 	static QRegExp rfb("{.*}");
 	static QRegExp rrb("\\(.*\\)");
 	static QRegExp stripB("^[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*");
 	static QRegExp stripE("[()_{}[]!@#$^&*+=|\\\\/\"'?<>~`\\s\\t]*$");
+#endif
 	QString s(component);
 
 	if (s.isEmpty()) {

--- a/musiccontroller.h
+++ b/musiccontroller.h
@@ -19,6 +19,7 @@
 #ifndef WATCHFISH_MUSICCONTROLLER_H
 #define WATCHFISH_MUSICCONTROLLER_H
 
+#include <QObject>
 #include <AmberMpris/mprismetadata.h>
 #include <QtCore/QLoggingCategory>
 

--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -16,12 +16,12 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QRegularExpression>
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
 #include <QtCore/QMessageLogger>
 #include <QtCore/QSettings>
 #include <QtCore/QSocketNotifier>
-#include <QRegularExpression>
 
 #include "notification.h"
 #include "notificationmonitor.h"
@@ -278,7 +278,11 @@ ProtoNotification NotificationMonitorPrivate::parseNotifyCall(DBusMessage *msg) 
     // Lookup category info and merge it with the notification info if found.
 	if (hints.contains("category")) {
 		proto.hints = getCategoryInfo(hints["category"]);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+		proto.hints.insert(hints);
+#else
 		proto.hints.unite(hints);
+#endif
 	} else {
 		proto.hints = hints;
 	}


### PR DESCRIPTION
I believe all platforms will work. In the other branch I have done tests with Sailfish OS, Ubuntu Touch, and Kirigami on Desktop. 
Some packages might be unavailable, but I believe we can solve it when migrating platform to qt6. For example timed-qt${QT_VERSION_MAJOR} or libmkcal-qt${QT_VERSION_MAJOR} might be available only as timed-qt5 and libmkcal-qt5.

I was trying to check all those features separately
- https://github.com/jmlich/notifex
- https://github.com/jmlich/mprisex
- https://github.com/jmlich/calendarex (focused on ubuntu touch)