### PR TITLE
[NotificationMonitor] Add BecomeMonitor interface, allow dismiss notification

### DIFF
--- a/notification.cpp
+++ b/notification.cpp
@@ -63,6 +63,7 @@ Notification::Notification(uint id, QObject *parent) : QObject(parent), d_ptr(ne
 
 Notification::~Notification()
 {
+	delete d_ptr;
 }
 
 uint Notification::id() const

--- a/notification.h
+++ b/notification.h
@@ -57,7 +57,7 @@ class Notification : public QObject
 
 
 public:
-	explicit Notification(uint id, QObject *parent = 0);
+	explicit Notification(uint id = 0, QObject *parent = 0);
 	~Notification();
 
 	enum CloseReason {

--- a/notificationmonitor.cpp
+++ b/notificationmonitor.cpp
@@ -45,8 +45,11 @@ QDebug operator<<(QDebug &debug, const ProtoNotification &proto)
 }
 
 NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
-	: q_ptr(q)
+    : QObject(q), q_ptr(q)
 {
+	connect(this, &NotificationMonitorPrivate::notificationClosed, q,
+		&NotificationMonitor::notificationClosed);
+
 	DBusError error = DBUS_ERROR_INIT;
 	_conn = dbus_bus_get_private(DBUS_BUS_SESSION, &error);
 	if (!_conn) {
@@ -59,9 +62,43 @@ NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
 	dbus_connection_set_watch_functions(_conn, busWatchAdd, busWatchRemove,
 										busWatchToggle, this, NULL);
 
-	addMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
-	addMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
-	addMatchRule("type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'");
+	bool became_monitor = false;
+	const char *rules[] = {
+		"type='method_call',interface='org.freedesktop.Notifications',member='Notify'",
+		"type='method_return',sender='org.freedesktop.Notifications'",
+		"type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'"
+	};
+
+	DBusMessage *msg = dbus_message_new_method_call("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus.Monitoring", "BecomeMonitor");
+	if (msg) {
+		dbus_uint32_t flags = 0;
+		DBusMessageIter iter, sub;
+		dbus_message_iter_init_append(msg, &iter);
+		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "s", &sub);
+		for (int i = 0; i < 3; ++i) {
+			dbus_message_iter_append_basic(&sub, DBUS_TYPE_STRING, &rules[i]);
+		}
+		dbus_message_iter_close_container(&iter, &sub);
+		dbus_message_iter_append_basic(&iter, DBUS_TYPE_UINT32, &flags);
+
+		DBusMessage *reply = dbus_connection_send_with_reply_and_block(_conn, msg, -1, &error);
+		if (reply) {
+			dbus_message_unref(reply);
+			became_monitor = true;
+			qCDebug(notificationMonitorCat) << "Became monitor";
+		} else {
+			qCDebug(notificationMonitorCat) << "Could not become monitor:" << (error.message ? error.message : "unknown error");
+			dbus_error_free(&error);
+		}
+		dbus_message_unref(msg);
+	}
+
+	if (!became_monitor) {
+		qCDebug(notificationMonitorCat) << "Falling back to legacy eavesdropping";
+		addMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
+		addMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
+		addMatchRule("type='signal',sender='org.freedesktop.Notifications',path='/org/freedesktop/Notifications',interface='org.freedesktop.Notifications',member='NotificationClosed'");
+	}
 
 	dbus_bool_t result = dbus_connection_add_filter(_conn, busMessageFilter,
 													this, NULL);
@@ -74,11 +111,8 @@ NotificationMonitorPrivate::NotificationMonitorPrivate(NotificationMonitor *q)
 
 NotificationMonitorPrivate::~NotificationMonitorPrivate()
 {
-	QMap<quint32, Notification*>::iterator it = _notifs.begin();
-	while (it != _notifs.end()) {
-		delete it.value();
-	}
-
+	qDeleteAll(_notifs);
+	_notifs.clear();
 #if 0 /* No need to remove match rules since we're closing the connection. */
 	removeMatchRule("type='method_call',interface='org.freedesktop.Notifications',member='Notify',eavesdrop='true'");
 	removeMatchRule("type='method_return',sender='org.freedesktop.Notifications',eavesdrop='true'");
@@ -150,6 +184,8 @@ void NotificationMonitorPrivate::processIncomingNotification(quint32 id, const P
 void NotificationMonitorPrivate::processCloseNotification(quint32 id, quint32 reason)
 {
 	qCDebug(notificationMonitorCat) << "Close notification" << id << reason;
+	emit notificationClosed(id, reason);
+
 	Notification *n = _notifs.value(id, 0);
 	if (n) {
 		_notifs.remove(id);
@@ -479,5 +515,11 @@ NotificationMonitor::~NotificationMonitor()
 {
 	delete d_ptr;
 }
+
+Notification *NotificationMonitor::getNotification(uint id) const {
+	Q_D(const NotificationMonitor);
+	return d->_notifs.value(id, nullptr);
+}
+
 
 }

--- a/notificationmonitor.h
+++ b/notificationmonitor.h
@@ -41,9 +41,12 @@ public:
 	explicit NotificationMonitor(QObject *parent = 0);
 	~NotificationMonitor();
 
+    Q_INVOKABLE watchfish::Notification* getNotification(uint id) const;
+
 signals:
     /** Emitted when a notification arrives. */
     void notification(watchfish::Notification *n);
+    void notificationClosed(quint32 nid, quint32 reason);
 
 private:
 	NotificationMonitorPrivate * const d_ptr;

--- a/notificationmonitor_p.h
+++ b/notificationmonitor_p.h
@@ -55,6 +55,9 @@ public:
     explicit NotificationMonitorPrivate(NotificationMonitor *q);
 	~NotificationMonitorPrivate();
 
+signals:
+    void notificationClosed(quint32 nid, quint32 reason);
+
 private:
 	/** Converts a ProtoNotification into a Notification object and raises it. */
 	void processIncomingNotification(quint32 id, const ProtoNotification &proto);


### PR DESCRIPTION
- Replace deprecated D-Bus eavesdrop='true' with BecomeMonitor API, falling back to eavesdrop on older systems. https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-become-monitor

> Eavesdropping interacts poorly with buses with non-trivial access control restrictions, and is deprecated

- Fix memory leak in ~Notification() and broken destructor loop
- Add getNotification() and notificationClosed signal to sync notification dismissal between phone and smartwatch